### PR TITLE
Add 'Valid' annotation to all properties of type list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- 
-    deploy with (-X is for verbose error reporting): 
+  <!--
+    deploy with (-X is for verbose error reporting):
       mvn -Possrh clean deploy -X
     check results on:
       https://oss.sonatype.org/#nexus-search;quick~com.fillumina
@@ -11,7 +11,7 @@
 
   <groupId>com.fillumina</groupId>
   <artifactId>krasa-jaxb-tools</artifactId>
-  <version>2.1</version>
+  <version>2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>krasa-jaxb-tools</name>
 
@@ -75,7 +75,7 @@
   </build>
 
   <dependencies>
-    
+
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
@@ -89,7 +89,7 @@
       <version>2.3.1</version>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
@@ -114,7 +114,7 @@
       <artifactId>validator-collection</artifactId>
       <version>2.2.0</version>
     </dependency>
-    
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -187,7 +187,7 @@
               <javadocExecutable>
                 ${java.home}/bin/javadoc
               </javadocExecutable>
-            </configuration>            
+            </configuration>
           </plugin>
           <plugin>
             <!-- https://central.sonatype.org/publish/publish-maven/#gpg-signed-components -->
@@ -204,7 +204,7 @@
                 <configuration>
                   <keyname>${gpg.keyname}</keyname>
                   <passphraseServerId>${gpg.passphrase}</passphraseServerId>
-                </configuration>                
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -212,7 +212,7 @@
       </build>
     </profile>
   </profiles>
-  
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
@@ -227,5 +227,5 @@
       <!--<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
     </repository>
   </distributionManagement>
-  
+
 </project>

--- a/src/test/java/com/sun/tools/xjc/addon/krasa/ListsTest.java
+++ b/src/test/java/com/sun/tools/xjc/addon/krasa/ListsTest.java
@@ -23,6 +23,7 @@ public class ListsTest extends RunXJC2MojoTestHelper {
     public void testContainer() {
         element("Container")
                 .attribute("listOfString")
+                        .annotation("Valid").assertNoValues()
                         .annotation("Size")
                             .assertParam("min", 0)
                             .assertParam("max", 5).end()
@@ -38,6 +39,7 @@ public class ListsTest extends RunXJC2MojoTestHelper {
                         .annotation("Valid").assertNoValues()
                         .end()
                 .attribute("listOfPercentage")
+                        .annotation("Valid").assertNoValues()
                         .annotation("Size")
                             .assertParam("min", 2)
                             .assertParam("max", 4).end()


### PR DESCRIPTION
(Moved from #3)
I encountered a problem with the Java code generated by v1.8 of this (otherwise excellent) plugin, for an XSD schema containing list elements.

An example XSD file was [GuiaRemision_V1.0.0.xsd.txt](https://github.com/fillumina/krasa-jaxb-tools/files/9352506/GuiaRemision_V1.0.0.xsd.txt)
The Java generated was [GuiaRemision.java.txt](https://github.com/fillumina/krasa-jaxb-tools/files/9352519/GuiaRemision.java.txt)
Of particular note was the list properties, e.g.
```
    public static class Destinatarios {

        @XmlElement(required = true)
        @NotNull(message = "Destinatarios.destinatario {javax.validation.constraints.NotNull.message}")
        @Size(min = 1)
        protected List<Destinatario> destinatario;
```

Performing validation of this class using `hibernate-validator:6.2.4.Final` did not detect any validation errors for elements of the "destinatario" list property.

However, modifying the Java code to add a '@Valid' annotation to the property, as per:
```
    public static class Destinatarios {

        @XmlElement(required = true)
        @Valid  
        @NotNull(message = "Destinatarios.destinatario {javax.validation.constraints.NotNull.message}")
        @Size(min = 1)
        protected List<Destinatario> destinatario;
``` 
changed this behaviour such that the validation annotations on list elements did result in validation errors. (See suggestion also via https://stackoverflow.com/a/44652479)

Therefore, this patch adds a @Valid annotation to any and all list properties.

In my case, the resultant (working) Java code was [GuiaRemision.java.txt](https://github.com/fillumina/krasa-jaxb-tools/files/9352584/GuiaRemision.java.txt)

----
Commentary on code changes:

* main change is JaxbValidationPlugins.java lines 201 and 434, with accompanying unit test change in ListsTest.java
* however, I also encountered errors with the cast to `ElementDecl` in JaxbValidationPlugins.java line 174. (The WSDL I was processing - see above - resulted in `processElement` being called with a `ModelGroupImpl` element, and so the cast failed.)
