### PR TITLE
Resolve bug causing multiple @Valid annotations on List-types

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,16 +4,7 @@ Plugin for generation of Bean Validation Annotations (JSR-303) **-XJsr303Annotat
 
 Versions
 ----------------
-
-- `2.2` Some new features added because of PR requests
-  
-  - Added `@Valid` annotation to `sequence`s to force items validation
-  - Added support for `Jakarta EE 9` with parameter `validationAnnotations`
-
-- `2.1` Revert back to Java 1.8 (sorry folks!).
-
-- `2.0` A refactorized version of the original [krasa-jaxb-toos](https://github.com/krasa/krasa-jaxb-tools) last synced on August 2022, with some enhancements (support for `EachDigits`, `EachDecimalMin` and `EachDecimalMax` in primitive lists), improved tests and bug fixed. It is compiled using JDK 11. The `pom.xml` `groupId` has been changed to `com.fillumina`.
-
+- `2.2.1` Resolved a bug in which sometimes the `@Valid` annotation is applied twice to List types.
 -----
 
 Release

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.fillumina</groupId>
   <artifactId>krasa-jaxb-tools</artifactId>
-  <version>2.3-SNAPSHOT</version>
+  <version>2.2.1</version>
   <packaging>jar</packaging>
   <name>krasa-jaxb-tools</name>
 
@@ -30,9 +30,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:fillumina/krasa-jaxb-tools.git</connection>
-    <url>git@github.com:fillumina/krasa-jaxb-tools.git</url>
-    <developerConnection>scm:git:git@github.com:fillumina/krasa-jaxb-tools.git</developerConnection>
+    <connection>scm:git:git@github.com:Viserius/krasa-jaxb-tools.git</connection>
+    <url>git@github.com:Viserius/krasa-jaxb-tools.git</url>
+    <developerConnection>scm:git:git@github.com:Viserius/krasa-jaxb-tools.git</developerConnection>
   </scm>
 
   <developers>
@@ -43,6 +43,10 @@
     <developer>
       <name>Vojtech Krasa</name>
       <email>vojta.krasa@gmail.com</email>
+    </developer>
+    <developer>
+      <name>Viserius</name>
+      <url>https://github.com/Viserius/krasa-jaxb-tools</url>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
       https://oss.sonatype.org/#nexus-search;quick~com.fillumina
   -->
 
-  <groupId>com.fillumina</groupId>
+  <groupId>io.github.viserius</groupId>
   <artifactId>krasa-jaxb-tools</artifactId>
   <version>2.2.1</version>
   <packaging>jar</packaging>
@@ -52,6 +52,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
   </properties>
 
   <build>
@@ -60,7 +62,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.2.5</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -69,10 +71,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.12.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>
@@ -152,7 +154,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.8.6</version>
+      <version>3.9.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -171,10 +173,9 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>3.3.0</version>
             <executions>
               <execution>
-                <phase>verify</phase>
                 <id>attach-sources</id>
                 <goals>
                   <goal>jar-no-fork</goal>
@@ -185,7 +186,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.6.3</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -194,17 +195,12 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <javadocExecutable>
-                ${java.home}/bin/javadoc
-              </javadocExecutable>
-            </configuration>
           </plugin>
           <plugin>
             <!-- https://central.sonatype.org/publish/publish-maven/#gpg-signed-components -->
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -214,10 +210,19 @@
                 </goals>
                 <configuration>
                   <keyname>${gpg.keyname}</keyname>
-                  <passphraseServerId>${gpg.passphrase}</passphraseServerId>
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.1.6</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenEnabled>true</tokenEnabled>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -227,16 +232,8 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <!-- I'm on an old legacy repository... -->
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <!--<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>-->
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <!-- I'm on an old legacy repository... -->
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      <!--<url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
-    </repository>
   </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.github.viserius</groupId>
   <artifactId>krasa-jaxb-tools</artifactId>
-  <version>2.2.1</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>krasa-jaxb-tools</name>
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -38,6 +38,7 @@ import org.xml.sax.ErrorHandler;
  * @author Francesco Illuminati
  * @author Vojtěch Krása
  * @author cocorossello
+ * @author Viserius
  */
 public class JaxbValidationsPlugins extends Plugin {
 
@@ -190,10 +191,6 @@ public class JaxbValidationsPlugins extends Plugin {
                 !hasAnnotation(field, "NotNull")) {
 
             addNotNullAnnotation(classOutline, field);
-        }
-
-        if (property.isCollection()) {
-            addValidAnnotation(propertyName, classOutline.implClass.name(), field);
         }
 
         // https://www.ibm.com/developerworks/webservices/library/ws-tip-null/index.html

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/Utils.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/Utils.java
@@ -6,6 +6,7 @@ import java.math.BigInteger;
 
 /**
  * @author Vojtech Krasa
+ * @author Viserius
  */
 class Utils {
 
@@ -108,6 +109,7 @@ class Utils {
 		if(var == null) {
 			return false;
 		}
-        return "JDirectClass".equals(var.type().getClass().getSimpleName());
+        return "JDirectClass".equals(var.type().getClass().getSimpleName())
+				|| "JNarrowedClass".equals(var.type().getClass().getSimpleName());
     }
 }


### PR DESCRIPTION
For our XSD which I am unable to share, sometimes two @Valid annotations are added to Lists.
This PR fixes this problem, by reverting back to the original approach of checking whether an annotation was added already.