### PR TITLE
add primitive fixer plugin to autodiscovery

### DIFF
--- a/src/main/resources/META-INF/services/com.sun.tools.xjc.Plugin
+++ b/src/main/resources/META-INF/services/com.sun.tools.xjc.Plugin
@@ -1,1 +1,2 @@
 com.sun.tools.xjc.addon.krasa.JaxbValidationsPlugins
+com.sun.tools.xjc.addon.krasa.PrimitiveFixerPlugin


### PR DESCRIPTION
It wasn't possible to use the `-XReplacePrimitives` with `com.github.bjornvester.wsdl2java` gradle plugin.