### PR TITLE
fix: numeric annotations applied to String java type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.fillumina</groupId>
   <artifactId>krasa-jaxb-tools</artifactId>
-  <version>2.3.5</version>
+  <version>2.3.6</version>
   <packaging>jar</packaging>
   <name>krasa-jaxb-tools</name>
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
@@ -211,7 +211,7 @@ public class Processor {
             if (fieldHelper.isArray()) {
                 annotator.addSizeAnnotation(facet.minLength(), facet.maxLength(), facet.length());
 
-            } else if (fieldHelper.isNumber()) {
+            } else if (fieldHelper.isNumber() || fieldHelper.isString()) {
                 if (options.isAllNumericConstraints()) {
                     annotator.addDecimalMinAnnotationInclusive(facet.minInclusive());
                     annotator.addDecimalMinAnnotationExclusive(facet.minExclusive());
@@ -227,12 +227,12 @@ public class Processor {
 
                 annotator.addDigitsAnnotation(facet.totalDigits(), facet.fractionDigits());
 
-            } else if (fieldHelper.isString()) {
-                annotator.addSizeAnnotation(facet.minLength(), facet.maxLength(), facet.length());
+                if (fieldHelper.isString()) {
+                    annotator.addSizeAnnotation(facet.minLength(), facet.maxLength(), facet.length());
 
-                Set<String> patternSet = gatherRegexpAndEnumeration(facet, simpleType);
-                annotator.addPatterns(patternSet);
-
+                    Set<String> patternSet = gatherRegexpAndEnumeration(facet, simpleType);
+                    annotator.addPatterns(patternSet);
+                }
             } else if (fieldHelper.isStringList() && options.isValidationCollection()) {
                 annotator.addEachSizeAnnotation(facet.minLength(), facet.maxLength());
 

--- a/src/test/resources/abase/Complex-annotation.txt
+++ b/src/test/resources/abase/Complex-annotation.txt
@@ -204,12 +204,6 @@ CustomizationInfoType
         @NotNull
         @Size(min = 1, max = 50)
 DataTransferUnitOfMeasure
-DateIntegerDimension
-    unitOfMeasure
-        @NotNull
-    value
-        @DecimalMin(value = "1", inclusive = true)
-DateUnitOfMeasure
 DatedCompareAtPrice
     compareAtPrice
         @NotNull
@@ -225,6 +219,12 @@ DatedPrice
     price
         @Valid
     startDate
+DateIntegerDimension
+    unitOfMeasure
+        @NotNull
+    value
+        @DecimalMin(value = "1", inclusive = true)
+DateUnitOfMeasure
 DegreeDimension
     unitOfMeasure
         @NotNull

--- a/src/test/resources/abase/DefaultOption-annotation.txt
+++ b/src/test/resources/abase/DefaultOption-annotation.txt
@@ -204,12 +204,6 @@ CustomizationInfoType
         @NotNull
         @Size(min = 1, max = 50)
 DataTransferUnitOfMeasure
-DateIntegerDimension
-    unitOfMeasure
-        @NotNull
-    value
-        @DecimalMin(value = "1", inclusive = true)
-DateUnitOfMeasure
 DatedCompareAtPrice
     compareAtPrice
         @NotNull
@@ -225,6 +219,12 @@ DatedPrice
     price
         @Valid
     startDate
+DateIntegerDimension
+    unitOfMeasure
+        @NotNull
+    value
+        @DecimalMin(value = "1", inclusive = true)
+DateUnitOfMeasure
 DegreeDimension
     unitOfMeasure
         @NotNull


### PR DESCRIPTION
#18 the fix supports numeric annotations on the final String java types. Using bindings.xjb the java types can be changed irrespective of the declared datatypes in the xsd. This fix will allow generated String types to have additional numeric annotations such as Digits, DecimalMin, DecimalMax which are allowed on the Strings