### PR TITLE
Fix for javax valid being used in generated SOAP interfaces regardless

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaInterface.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaInterface.java
@@ -1,0 +1,21 @@
+package com.sun.tools.xjc.addon.krasa.validations;
+
+import org.apache.cxf.tools.common.model.JavaInterface;
+
+import java.lang.annotation.Annotation;
+
+public class ProcessorForJavaInterface {
+    private final Class<? extends Annotation> validClass;
+    private final ProcessorForJavaMethod processorForJavaMethod;
+
+    public ProcessorForJavaInterface(ValidationsOptions validationsOptions) {
+        this.validClass = validationsOptions.getAnnotationFactory().getValidClass();
+        this.processorForJavaMethod = new ProcessorForJavaMethod(validationsOptions);
+    }
+
+    public void process(JavaInterface javaInterface) {
+        javaInterface.addImport(validClass.getCanonicalName());
+
+        javaInterface.getMethods().forEach(processorForJavaMethod::process);
+    }
+}

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaMethod.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaMethod.java
@@ -1,0 +1,51 @@
+package com.sun.tools.xjc.addon.krasa.validations;
+
+import org.apache.cxf.tools.common.model.JAnnotation;
+import org.apache.cxf.tools.common.model.JavaMethod;
+import org.apache.cxf.tools.common.model.JavaParameter;
+
+public class ProcessorForJavaMethod {
+
+    private static final String NAME = ProcessorForJavaMethod.class.getSimpleName();
+    private static final String LOG_PREFIX = NAME + ": ";
+    private static final String VALID_PARAM = "VALID_PARAM";
+    private static final String VALID_RETURN = "VALID_RETURN";
+
+    private final ValidationsOptions validationsOptions;
+    private final JAnnotation VALID_ANNOTATION_CLASS;
+
+    public ProcessorForJavaMethod(ValidationsOptions validationsOptions) {
+        this.validationsOptions = validationsOptions;
+        this.VALID_ANNOTATION_CLASS = new JAnnotation(
+                validationsOptions
+                        .getAnnotationFactory()
+                        .getValidClass()
+        );
+    }
+
+    public void process(JavaMethod javaMethod) {
+        if (validationsOptions.isValidOut()) {
+            log("adding annotation to " + javaMethod.getSignature());
+            javaMethod.addAnnotation(VALID_RETURN, VALID_ANNOTATION_CLASS);
+        }
+
+        javaMethod.getParameters().forEach(this::process);
+    }
+
+    private void process(JavaParameter javaParameter) {
+        if (validationsOptions.isValidIn() && (javaParameter.isIN() || javaParameter.isINOUT())) {
+            log("adding in " + javaParameter.getName());
+            javaParameter.addAnnotation(VALID_PARAM, VALID_ANNOTATION_CLASS);
+        }
+        if (validationsOptions.isValidOut() && (javaParameter.isOUT() || javaParameter.isINOUT())) {
+            log("adding out " + javaParameter.getName());
+            javaParameter.addAnnotation(VALID_RETURN, VALID_ANNOTATION_CLASS);
+        }
+    }
+
+    void log(String message) {
+        if (validationsOptions.isVerbose()) {
+            System.out.println(LOG_PREFIX + message);
+        }
+    }
+}

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaModel.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ProcessorForJavaModel.java
@@ -1,0 +1,18 @@
+package com.sun.tools.xjc.addon.krasa.validations;
+
+import org.apache.cxf.tools.common.model.JavaModel;
+
+public class ProcessorForJavaModel {
+    private final ProcessorForJavaInterface processorForJavaInterface;
+
+    public ProcessorForJavaModel(ValidationsOptions validationsOptions) {
+        this.processorForJavaInterface = new ProcessorForJavaInterface(validationsOptions);
+    }
+
+    public void process(JavaModel javaModel) {
+        javaModel
+                .getInterfaces()
+                .values()
+                .forEach(processorForJavaInterface::process);
+    }
+}

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ValidationsArgument.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ValidationsArgument.java
@@ -112,7 +112,15 @@ public enum ValidationsArgument {
     generateServiceValidationAnnotations(
             String.class,
             "used by cxf-codegen to performs validation on fields annotated with @Valid",
-            (p,v) -> null, // read by ValidSEIGenerator
+            (p,v) -> {
+                if ("in".equalsIgnoreCase(v)) {
+                    p.validOut(false);
+                } else if ("out".equalsIgnoreCase(v)) {
+                    p.validIn(false);
+                }
+                //log("'" + policy + "' parsed as " + "in = " + validIn + ", out = " + validOut);
+                return null;
+            }, // read by ValidSEIGenerator
             (p) -> null);
 
     // parameter type

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ValidationsOptions.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/ValidationsOptions.java
@@ -20,6 +20,8 @@ public class ValidationsOptions {
     private final String notNullCustomMessageText;
     private final boolean validationCollection;
     private final ValidationsAnnotation annotationFactory;
+    private final boolean validIn;
+    private final boolean validOut;
 
     public void logActualOptions() {
         if (verbose) {
@@ -89,6 +91,14 @@ public class ValidationsOptions {
         return annotationFactory;
     }
 
+    public boolean isValidIn() {
+        return validIn;
+    }
+
+    public boolean isValidOut() {
+        return validOut;
+    }
+
     public static class Builder {
         private String targetNamespace = null;
         private boolean verbose = false;
@@ -100,6 +110,8 @@ public class ValidationsOptions {
         private String notNullCustomMessageText = null;
         private boolean validationCollection = false;
         private ValidationsAnnotation annotationFactory = ValidationsAnnotation.JAVAX;
+        private boolean validIn = true;
+        private boolean validOut = true;
 
         private Builder() {
         }
@@ -190,11 +202,21 @@ public class ValidationsOptions {
             return this;
         }
 
+        public Builder validIn(final boolean value) {
+            this.validIn = value;
+            return this;
+        }
+
+        public Builder validOut(final boolean value) {
+            this.validOut = value;
+            return this;
+        }
+
         public ValidationsOptions build() {
             return new com.sun.tools.xjc.addon.krasa.validations.ValidationsOptions(targetNamespace,
                     verbose, allNumericConstraints, notNullAnnotations, notNullCustomMessage,
                     notNullPrefixFieldName, notNullPrefixClassName, notNullCustomMessageText,
-                    validationCollection, annotationFactory);
+                    validationCollection, annotationFactory, validIn, validOut);
         }
     }
 
@@ -207,7 +229,9 @@ public class ValidationsOptions {
             final boolean notNullCustomMessage, final boolean notNullPrefixFieldName,
             final boolean notNullPrefixClassName, final String notNullCustomMessageText,
             final boolean validationCollection,
-            final ValidationsAnnotation annotationFactory) {
+            final ValidationsAnnotation annotationFactory,
+            final boolean validIn,
+            final boolean validOut) {
         this.targetNamespace = targetNamespace;
         this.verbose = verbose;
         this.allNumericConstraints = allNumericConstraints;
@@ -218,6 +242,8 @@ public class ValidationsOptions {
         this.notNullCustomMessageText = notNullCustomMessageText;
         this.validationCollection = validationCollection;
         this.annotationFactory = annotationFactory;
+        this.validIn = validIn;
+        this.validOut = validOut;
     }
 
 }


### PR DESCRIPTION
Fix for javax valid being used in generated SOAP interfaces regardless of settings given to the plugin to use Jakarta instead of Javax