### PR TITLE
Fix for duplicated regex-pattern

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
@@ -17,12 +17,7 @@ import com.sun.xml.xsom.impl.AttributeUseImpl;
 import com.sun.xml.xsom.impl.ElementDecl;
 import com.sun.xml.xsom.impl.SimpleTypeImpl;
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -266,7 +261,7 @@ public class Processor {
                 if (baseType instanceof XSRestrictionSimpleType) {
                     Facet baseFacet = new Facet((XSRestrictionSimpleType) baseType);
 
-                    addIfNotNullOrEmpty(multiPatterns, getPatterns(baseFacet), Collection::isEmpty);
+                    addIfNotNullOrEmpty(multiPatterns, getPatterns(baseFacet).stream().filter(pattern -> !patterns.contains(pattern)).collect(Collectors.toList()), Collection::isEmpty);
                     addAllIfNotNullOrEmpty(multiEnumerations, getEnumerations(baseFacet), String::isEmpty);
                 }
             }

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/validations/Processor.java
@@ -261,7 +261,10 @@ public class Processor {
                 if (baseType instanceof XSRestrictionSimpleType) {
                     Facet baseFacet = new Facet((XSRestrictionSimpleType) baseType);
 
-                    addIfNotNullOrEmpty(multiPatterns, getPatterns(baseFacet).stream().filter(pattern -> !patterns.contains(pattern)).collect(Collectors.toList()), Collection::isEmpty);
+                    List<String> nonDuplicatedPattern = getPatterns(baseFacet).stream()
+                            .filter(pattern -> !patterns.contains(pattern))
+                            .collect(Collectors.toList());
+                    addIfNotNullOrEmpty(multiPatterns, nonDuplicatedPattern, Collection::isEmpty);
                     addAllIfNotNullOrEmpty(multiEnumerations, getEnumerations(baseFacet), String::isEmpty);
                 }
             }

--- a/src/test/java/com/sun/tools/xjc/addon/krasa/validations/jaxb/PatternWithBase.java
+++ b/src/test/java/com/sun/tools/xjc/addon/krasa/validations/jaxb/PatternWithBase.java
@@ -1,0 +1,11 @@
+package com.sun.tools.xjc.addon.krasa.validations.jaxb;
+
+import com.sun.tools.xjc.addon.krasa.validations.AnnotationCheckerTestHelper;
+
+public class PatternWithBase extends AnnotationCheckerTestHelper {
+
+    public PatternWithBase() {
+        super("patternWithBase", "a", "PatternWithBase");
+    }
+
+}

--- a/src/test/resources/patternWithBase/patternWithBase-a-annotation.txt
+++ b/src/test/resources/patternWithBase/patternWithBase-a-annotation.txt
@@ -1,0 +1,3 @@
+PatternWithBase
+    patternWithBase
+        @Pattern(regexp = "([0-3])|([7-9])*")

--- a/src/test/resources/patternWithBase/patternWithBase.xsd
+++ b/src/test/resources/patternWithBase/patternWithBase.xsd
@@ -1,0 +1,26 @@
+<xsd:schema
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="a"
+    xmlns:a="a"
+    elementFormDefault="qualified">
+
+    <xsd:element name="patternwithbase" type="a:PatternWithBase"/>
+
+    <xsd:complexType name="PatternWithBase">
+        <xsd:sequence>
+            <xsd:element name="patternWithBase" type="a:PatternWithSize" minOccurs="0" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:simpleType name="PatternWithSize">
+        <xsd:restriction base="a:BasePatternType" />
+    </xsd:simpleType>
+
+    <xsd:simpleType name="BasePatternType">
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern
+                    value="([0-3])|([7-9])*" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>


### PR DESCRIPTION
Fix for special constellations where there would be duplicated regex pattern when only the basetype has an pattern. On validation it otherwise would throw:
java.lang.annotation.AnnotationFormatError: Duplicate annotation for class: interface jakarta.validation.constraints.Pattern: 